### PR TITLE
Disable broken Wi-Fi Display support

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -157,20 +157,6 @@
     <!-- reference volume index for music stream to limit headphone volume and display warning -->
     <integer name="config_safe_media_volume_index">18</integer>
 
-    <!-- Whether WiFi display is supported by this device.
-         There are many prerequisites for this feature to work correctly.
-         Here are a few of them:
-         * The WiFi radio must support WiFi P2P.
-         * The WiFi radio must support concurrent connections to the WiFi display and
-           to an access point.
-         * The Audio Flinger audio_policy.conf file must specify a rule for the "r_submix"
-           remote submix module.  This module is used to record and stream system
-           audio output to the WiFi display encoder in the media server.
-         * The remote submix module "audio.r_submix.default" must be installed on the device.
-         * The device must be provisioned with HDCP keys (for protected content).
-    -->
-    <bool name="config_enableWifiDisplay">true</bool>
-
     <!-- Flag indicating if the speed up audio on mt call code should be executed -->
     <bool name="config_speed_up_audio_on_mt_calls">true</bool>
 


### PR DESCRIPTION
This PR disables Wi-Fi Display feature (Miracast) since it doesn't work anymore starting from Android 9 (Google removed support for it). I've used this [LineageOS patch](https://review.lineageos.org/c/LineageOS/android_device_fairphone_FP2/+/245324) as a reference.
Trying to cast the screen to a Miracast device results in the system server crashing with the following exception:
```
*** FATAL EXCEPTION IN SYSTEM PROCESS: android.display
java.lang.IllegalStateException: Could not start listening for remote display connection on "192.168.211.190:7236"
 at android.media.RemoteDisplay.startListening(RemoteDisplay.java:123)
 at android.media.RemoteDisplay.listen(RemoteDisplay.java:85)
 at com.android.server.display.WifiDisplayController.updateConnection(WifiDisplayController.java:819)
 at com.android.server.display.WifiDisplayController.access$1200(WifiDisplayController.java:70)
 at com.android.server.display.WifiDisplayController$15.onGroupInfoAvailable(WifiDisplayController.java:916)
 at android.net.wifi.p2p.WifiP2pManager$Channel$P2pHandler.handleMessage(WifiP2pManager.java:985)
 at android.os.Handler.dispatchMessage(Handler.java:107)
 at android.os.Looper.loop(Looper.java:214)
 at android.os.HandlerThread.run(HandlerThread.java:67)
 at com.android.server.ServiceThread.run(ServiceThread.java:44)
```

Note that disabling Wi-Fi Display shouldn't affect the ability to cast to Chromecast devices, since they don't use Miracast.